### PR TITLE
Fix error that occurred when the language file content ends with a se…

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,11 @@ function loadTranslationsPath(id,path,reload){
     }
     
     try {
- 			if (translations.trim().endsWith(";")) {
+       // remove `"use strict";` at the beginning of the file (add generally by tanspiler like typescript) if present
+      if (/^\s*("use\sstrict");?/.test(translations)) {
+        translations = translations.replace(/^\s*"use\sstrict";?\s*/, '');
+      }
+      if (translations.trim().endsWith(";")) {
         translations = "(function(){return " + translations + "})();";
       } else {
         translations = "(function(){return " + translations + ";})();";

--- a/index.js
+++ b/index.js
@@ -75,7 +75,11 @@ function loadTranslationsPath(id,path,reload){
     }
     
     try {
-      translations = "(function(){return "+translations+";})();";
+ 			if (translations.trim().endsWith(";")) {
+        translations = "(function(){return " + translations + "})();";
+      } else {
+        translations = "(function(){return " + translations + ";})();";
+      }
       if(!jshint(translations)){
         var checkfail = jshint.data().errors;
         var jsHintError = new Error("Sheet sintax error");


### PR DESCRIPTION
When the language file content ends with **;** (that is a valid JS) for eg:
```
({
  sum: "The result of the operation {operation} is {result}",
  inbox: "You Have {mails} mensajes",
  hello: "Hi {firstname} {lastname}"
}); // semicolon
```
Instead of :
```
({
  sum: "The result of the operation {operation} is {result}",
  inbox: "You Have {mails} mensajes",
  hello: "Hi {firstname} {lastname}"
}) // no semicolon
```
Then the following error occurred :

```
  Line 6 > Unreachable ';' after 'return'.
         ...;})();...
  Line 6 > Unnecessary semicolon.
          ...;})();...
```

